### PR TITLE
Change time stamp display format %Y-%m-%d %H:%M:%S to %H:%M

### DIFF
--- a/slack_notificater.py
+++ b/slack_notificater.py
@@ -27,7 +27,7 @@ def schedules_format_message(data):
             {
                 'fallback': 'Detailed information on Splatoon Stage.',
                 'color': 'good',
-                'title': 'Stage Information at Ranked Battle from {} to {}'.format(datetime.datetime.fromtimestamp(notify_data['start_time']), datetime.datetime.fromtimestamp(notify_data['end_time'])),
+                'title': 'Stage Information at Ranked Battle from {} to {}'.format(datetime.datetime.fromtimestamp(notify_data['start_time']).strftime("%H:%M"), datetime.datetime.fromtimestamp(notify_data['end_time']).strftime("%H:%M")),
                 'fields': [
                     {
                         'title': 'Game Mode',


### PR DESCRIPTION
日付のformatを
Stage Information at Ranked Battle from 2018-08-30 01:00:00 to 2018-08-30 03:00:00
から
Stage Information at Ranked Battle from 01:00 to 03:00
に変更したい